### PR TITLE
Add initial support for setuptools in generated clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "swagger-codegen"
-version = "0.1.14"
+version = "0.1.15"
 description = "Generate API clients by parsing Swagger definitions"
 authors = ["asyncee"]
 license = "MIT"

--- a/src/swagger_codegen/templates/package_renderer/manifest_in.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/manifest_in.jinja2
@@ -1,0 +1,6 @@
+# https://docs.python.org/3/distutils/sourcedist.html#manifest
+include README.rst CHANGES LICENSE
+recursive-include requirements *.txt
+recursive-include {{ package_name }}
+exclude requirements/test.txt
+prune tests

--- a/src/swagger_codegen/templates/package_renderer/setup_py.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/setup_py.jinja2
@@ -1,0 +1,34 @@
+from pathlib import Path
+from setuptools import setup
+from setuptools import find_packages
+
+
+HERE = Path(__file__).absolute().parent
+
+with (HERE / 'README.md').open() as f:
+    README = f.read()
+
+
+# Setup
+# ----------------------------
+
+setup(name='{{ package_name }}',
+      version='{{ package_version }}',
+      description='{{ package_description }}',
+      long_description=README,
+      classifiers=[
+          'Intended Audience :: Developers',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 3',
+          'Operating System :: POSIX',
+          'Topic :: Internet :: WWW/HTTP',
+      ],
+      keywords='web',
+      packages=find_packages(exclude=['tests', 'tests.*']),
+      include_package_data=True,
+      zip_safe=False,
+      test_suite='tests',
+      tests_require=['pytest', 'coverage', 'wheel'],
+      install_requires=['pydantic', 'swagger_codegen'],
+      entry_points={}
+    )


### PR DESCRIPTION
Hi! I've implemented #3 from my work account.

I've used Nix to setup the dev environment, as I'm using multiple machines and it allows me to have a one-liner command to setup everything on a fresh hardware. I hope you don't mind it. It doesn't interfere with your `make bootstrap`.

This renderer API reminded me of [Cookiecutter](https://cookiecutter.readthedocs.io/en/1.7.2/). I have an [example template](https://github.com/avanov/python_project_template) that uses it for a generic python project , and I wonder if the same approach could be used here to offload project structure rendering to the third-party component.