### PR TITLE
Make generated client independent from swagger_codegen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "swagger-codegen"
-version = "0.1.15"
+version = "0.1.16"
 description = "Generate API clients by parsing Swagger definitions"
 authors = ["asyncee"]
 license = "MIT"

--- a/src/swagger_codegen/render/renderers/installable_package.py
+++ b/src/swagger_codegen/render/renderers/installable_package.py
@@ -1,8 +1,10 @@
+import os
+from pathlib import Path
+from pkg_resources import get_distribution
 from typing import List
 
 from swagger_codegen.parsing.endpoint import EndpointDescription
 
-from ..api import Api
 from .package import PackageRenderer
 
 
@@ -12,23 +14,38 @@ class InstallablePackageRenderer(PackageRenderer):
         *args,
         setup_py_template="package_renderer/setup_py.jinja2",
         manifest_in_template="package_renderer/manifest_in.jinja2",
+        readme_template="package_renderer/readme.jinja2",
         **kwargs,
     ):
         super(InstallablePackageRenderer, self).__init__(*args, **kwargs)
 
+        self._project_dir = self._directory / self._package_name
+        # second level of nesting is necessary to separate `setup.py` and meta-files (readme, tests etc)
+        # from the package files (runtime modules)
         self._package_dir = self._project_dir / self._package_name
+        self._package_api_lib_name = "lib"
+        self._package_api_lib_module_name = f"{self._package_name}.{self._package_api_lib_name}"
+
         self._setup_py_template = setup_py_template
         self._manifest_in_template = manifest_in_template
+        self._readme_template = readme_template
 
     def render(self, endpoints: List[EndpointDescription]):
         super().render(endpoints)
-        apis = self._get_apis(endpoints)
-        self._render_setuptools(apis)
+        self._render_setuptools()
 
-    def _render_setuptools(self, apis: List[Api]) -> None:
+    def _render_setuptools(self) -> None:
         """ Render files necessary for packaging the new client library with setuptools.
         """
-        (self._project_dir / "README.md").write_text("# Client Library")
+        (self._project_dir / "README.md").write_text(
+            self._render(
+                self._readme_template,
+                {
+                    "package_name": self._package_name,
+                    "package_api_lib_module_name": self._package_api_lib_module_name,
+                }
+            )
+        )
         ctx = {
             "package_name": self._package_name,
             "package_version": "1.0.0",
@@ -42,3 +59,19 @@ class InstallablePackageRenderer(PackageRenderer):
         (self._project_dir / "MANIFEST.in").write_text(
             self._render(self._manifest_in_template, ctx)
         )
+
+    def _render_low_level_lib(self, codegen_distribution: str) -> None:
+        """ Render ``swagger_codegen.api`` as ``<package_name>.lib``.
+        This way we make the generated client package independent from ``swagger_codegen``,
+        which saves our runtime from unnecessary dependencies in production.
+        """
+        dist = get_distribution(codegen_distribution)
+        src_lib_name = f'{codegen_distribution}.api'.encode('utf-8')
+        lib_location = Path(dist.location) / codegen_distribution / 'api'
+        lib = lib_location.rglob('*.py')
+        for src in lib:
+            lib_src = src.read_bytes().replace(src_lib_name, self._package_api_lib_module_name.encode('utf-8'))
+            lib_path = self._package_api_lib_dir / src.relative_to(lib_location)
+            if os.sep in str(lib_path):
+                lib_path.parent.mkdir(parents=True, exist_ok=True)
+            lib_path.write_bytes(lib_src)

--- a/src/swagger_codegen/templates/package_renderer/api.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/api.jinja2
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from swagger_codegen.api.base import BaseApi
+from {{ package_api_lib_module_name }}.base import BaseApi
 
 {% for endpoint in api.endpoints -%}
 from . import {{ endpoint.name }}

--- a/src/swagger_codegen/templates/package_renderer/client.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/client.jinja2
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from swagger_codegen.api.client import ApiClient
-from swagger_codegen.api.configuration import Configuration
-from swagger_codegen.api.adapter.base import HttpClientAdapter
+from {{ package_api_lib_module_name }}.client import ApiClient
+from {{ package_api_lib_module_name }}.configuration import Configuration
+from {{ package_api_lib_module_name }}.adapter.base import HttpClientAdapter
 
 {% for api in apis %}
 from .apis.{{ api.name }}.api import {{ api.type_name }}

--- a/src/swagger_codegen/templates/package_renderer/endpoint_imports.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/endpoint_imports.jinja2
@@ -7,5 +7,5 @@ import typing
 
 from pydantic import BaseModel
 
-from swagger_codegen.api.base import BaseApi
-from swagger_codegen.api.request import ApiRequest
+from {{ package_api_lib_module_name }}.base import BaseApi
+from {{ package_api_lib_module_name }}.request import ApiRequest

--- a/src/swagger_codegen/templates/package_renderer/package_entrypoint.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/package_entrypoint.jinja2
@@ -1,0 +1,4 @@
+from {{ package_api_lib_module_name }}.configuration import Configuration
+from .client import new_client
+
+__all__ = ('new_client', 'Configuration')

--- a/src/swagger_codegen/templates/package_renderer/readme.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/readme.jinja2
@@ -1,0 +1,28 @@
+# {{ package_name }}
+
+The client is provided with async and sync adapters.
+
+To install the async version with all its dependencies use:
+```bash
+pip install {{ package_name }}[asyncio]
+```
+
+To install the sync version with all its dependencies use:
+```bash
+pip install {{ package_name }}[sync]
+```
+
+To install both versions with all their dependencies use:
+```bash
+pip install {{ package_name }}[asyncio,sync]
+```
+
+## Client instantiation example
+
+```python
+
+from {{ package_name }} import new_client, Configuration
+from {{ package_api_lib_module_name }}.adapter.requests import RequestsAdapter
+
+client = new_client(RequestsAdapter(), Configuration(host="<your openapi server URL>"))
+```

--- a/src/swagger_codegen/templates/package_renderer/setup_py.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/setup_py.jinja2
@@ -29,6 +29,10 @@ setup(name='{{ package_name }}',
       zip_safe=False,
       test_suite='tests',
       tests_require=['pytest', 'coverage', 'wheel'],
-      install_requires=['pydantic', 'swagger_codegen'],
+      install_requires=['pydantic', 'multidict', 'schemathesis'],
+      extras_require={
+          'asyncio': ['aiohttp'],
+          'sync': ['requests'],
+      },
       entry_points={}
     )


### PR DESCRIPTION
Hi! This change makes all generated clients independent from `swagger_codegen`, which has a bunch of dependencies related to CLI, spec parsing, and testing components that I'd like to not depend on in a prod runtime environment.

Unfortunately, the client still is quite heavy as `schemathesis` alone brings the following packages:
```
Successfully installed
attrs-19.3.0
click-7.1.2
graphql-core-3.1.2
hypothesis-5.24.0
hypothesis-graphql-0.3.1
hypothesis-jsonschema-0.17.3
iniconfig-1.0.1
jsonschema-3.2.0
junit-xml-1.9
more-itertools-8.4.0
packaging-20.4
pluggy-0.13.1
py-1.9.0
pyparsing-2.4.7
pyrsistent-0.16.0
pytest-6.0.1
pytest-subtests-0.3.2
pyyaml-5.3.1
schemathesis-2.3.3
six-1.15.0
sortedcontainers-2.2.2
starlette-0.13.7
toml-0.10.1
werkzeug-1.0.1
```

I wonder if it can be removed too, as the types definitions seems to be relatively easy to replicate, and I think there's no need for `pytest`, `graphql`, and the entire `starlette` and `werkzeug ` frameworks.