### PR TITLE
Use valid python package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "swagger-codegen"
-version = "0.1.19"
+version = "0.1.20"
 description = "Generate API clients by parsing Swagger definitions"
 authors = ["asyncee"]
 license = "MIT"

--- a/src/swagger_codegen/render/renderers/installable_package.py
+++ b/src/swagger_codegen/render/renderers/installable_package.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from pkg_resources import get_distribution
 from typing import List
 
+from inflection import underscore
 from swagger_codegen.parsing.endpoint import EndpointDescription
 
 from .package import PackageRenderer
@@ -20,11 +21,12 @@ class InstallablePackageRenderer(PackageRenderer):
         super(InstallablePackageRenderer, self).__init__(*args, **kwargs)
 
         self._project_dir = self._directory / self._package_name
+        self._valid_python_package_name = underscore(self._package_name)
         # second level of nesting is necessary to separate `setup.py` and meta-files (readme, tests etc)
         # from the package files (runtime modules)
-        self._package_dir = self._project_dir / self._package_name
+        self._package_dir = self._project_dir / self._valid_python_package_name
         self._package_api_lib_name = "lib"
-        self._package_api_lib_module_name = f"{self._package_name}.{self._package_api_lib_name}"
+        self._package_api_lib_module_name = f"{self._valid_python_package_name}.{self._package_api_lib_name}"
 
         self._setup_py_template = setup_py_template
         self._manifest_in_template = manifest_in_template
@@ -41,13 +43,15 @@ class InstallablePackageRenderer(PackageRenderer):
             self._render(
                 self._readme_template,
                 {
-                    "package_name": self._package_name,
+                    "package_name": self._valid_python_package_name,
+                    "pypi_name": self._package_name,
                     "package_api_lib_module_name": self._package_api_lib_module_name,
                 }
             )
         )
         ctx = {
-            "package_name": self._package_name,
+            "package_name": self._valid_python_package_name,
+            "pypi_name": self._package_name,
             "package_version": "1.0.0",
             "package_description": self._package_name,
         }

--- a/src/swagger_codegen/templates/package_renderer/readme.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/readme.jinja2
@@ -1,20 +1,20 @@
-# {{ package_name }}
+# {{ pypi_name }}
 
 The client is provided with async and sync adapters.
 
 To install the async version with all its dependencies use:
 ```bash
-pip install {{ package_name }}[asyncio]
+pip install {{ pypi_name }}[asyncio]
 ```
 
 To install the sync version with all its dependencies use:
 ```bash
-pip install {{ package_name }}[sync]
+pip install {{ pypi_name }}[sync]
 ```
 
 To install both versions with all their dependencies use:
 ```bash
-pip install {{ package_name }}[asyncio,sync]
+pip install {{ pypi_name }}[asyncio,sync]
 ```
 
 ## Client instantiation example

--- a/src/swagger_codegen/templates/package_renderer/setup_py.jinja2
+++ b/src/swagger_codegen/templates/package_renderer/setup_py.jinja2
@@ -12,7 +12,7 @@ with (HERE / 'README.md').open() as f:
 # Setup
 # ----------------------------
 
-setup(name='{{ package_name }}',
+setup(name='{{ pypi_name }}',
       version='{{ package_version }}',
       description='{{ package_description }}',
       long_description=README,


### PR DESCRIPTION
Hi!

This PR fixes an issue with dasherized PyPI names. It preserves dasherized names for PyPI registry, but uses a proper underscored python name for imports.