### PR TITLE
APIs package init file

### DIFF
--- a/src/swagger_codegen/render/renderers/package.py
+++ b/src/swagger_codegen/render/renderers/package.py
@@ -104,6 +104,7 @@ class PackageRenderer(Renderer):
     def _render_api(self, api: Api):
         api_dir = self._package_dir / "apis" / api.name
         api_dir.mkdir(parents=True, exist_ok=True)
+        (api_dir.parent / "__init__.py").touch()
         (api_dir / "__init__.py").touch()
 
         api_py_content = self._render(


### PR DESCRIPTION
Hi! There's a small bug in the current autogenerated package structure where the parent `apis` doesn't contain a `__init__.py`  entry. The imports seems to be working fine locally, but during the package installation from wheels, the non-initialised folders get ignored by setuptools and the package is installed without the "apis" sub-package. This PR fixes it.