### PR TITLE
Do not expose readOnly fields on writes endpoints.

### DIFF
--- a/src/swagger_codegen/parsing/endpoint.py
+++ b/src/swagger_codegen/parsing/endpoint.py
@@ -42,14 +42,14 @@ class EndpointDescription:
         if self.endpoint.body:
             return EndpointRequest(
                 name=name,
-                data_type=make_data_type(self.endpoint.body),
+                data_type=make_data_type(self.endpoint.body, for_writes=True),
                 definition=self.endpoint.body,
                 content_type="application/json",
             )
         if self.endpoint.form_data:
             return EndpointRequest(
                 name=name,
-                data_type=make_data_type(self.endpoint.form_data),
+                data_type=make_data_type(self.endpoint.form_data, for_writes=True),
                 definition=self.endpoint.form_data,
                 content_type="multipart/form-data",
             )

--- a/tests/test_data_type_parser.py
+++ b/tests/test_data_type_parser.py
@@ -1,4 +1,5 @@
 import pytest
+
 from swagger_codegen.parsing.data_type import DataType, ObjectDataType
 from swagger_codegen.parsing.data_type_parser import make_data_type
 
@@ -128,6 +129,27 @@ def test_parse_complex_object():
                 member_value="None",
                 is_optional_type=True,
             ),
+            DataType(
+                python_type="str", member_name="field2", member_value="'some-value'"
+            ),
+        ],
+    )
+
+
+def test_parse_complex_object_read_only():
+    assert make_data_type(
+        {
+            "x-name": "Obj1",
+            "type": "object",
+            "properties": {
+                "field1": {"type": "integer", "readOnly": True},
+                "field2": {"type": "string", "default": "some-value"},
+            },
+        },
+        for_writes=True,
+    ) == ObjectDataType(
+        python_type="Obj1",
+        members=[
             DataType(
                 python_type="str", member_name="field2", member_value="'some-value'"
             ),


### PR DESCRIPTION
Otherwise the generated dataclass is expected to provide fields that the server will reject or ignore.