### PR TITLE
Decouple the Request Schema from Response Schema

### DIFF
--- a/src/swagger_codegen/parsing/data_type_parser.py
+++ b/src/swagger_codegen/parsing/data_type_parser.py
@@ -93,7 +93,9 @@ def make_data_type(
             )
 
         if "properties" in schema:
-            pt_name = object_name(schema)
+            if pt_name := object_name(schema):
+                if for_writes:
+                    pt_name += 'Request'
 
             # Case when parent has a field that is an object that does not have a name.
             # In that situation such field must be rendered as a separate python model (class)

--- a/tests/test_data_type_parser.py
+++ b/tests/test_data_type_parser.py
@@ -148,7 +148,7 @@ def test_parse_complex_object_read_only():
         },
         for_writes=True,
     ) == ObjectDataType(
-        python_type="Obj1",
+        python_type="Obj1Request",
         members=[
             DataType(
                 python_type="str", member_name="field2", member_value="'some-value'"


### PR DESCRIPTION
This will create endpoint definition files with multiple data classes

One for the request and one for the response

such as

```python
class FooRequest(BaseModel):
  field1: str


class Foo(BaseModel):
  field1: str
  id: int


def make_request(
       self: BaseApi,
        __request__: FooRequest,
    ) -> Foo:
    ...
```