### PR TITLE
add file_encoding support for gbk

### DIFF
--- a/src/swagger_codegen/parsing/loaders.py
+++ b/src/swagger_codegen/parsing/loaders.py
@@ -7,14 +7,14 @@ from schemathesis.schemas import BaseSchema
 def _from_json(file: str) -> dict:
     import json
 
-    with open(file) as fd:
+    with open(file, encoding="UTF-8") as fd:
         return json.load(fd)
 
 
 def _from_yaml(file: str):
     import yaml
 
-    with open(file) as fd:
+    with open(file, encoding="UTF-8") as fd:
         return yaml.load(fd)
 
 


### PR DESCRIPTION
Hello, when using the library you developed recently, I reported an error when Chinese characters were converted in my json file, so I changed the method of opening the file in your parsing-loaders.py file. I hope you will adopt mine. Suggestions, thanks
The error is as follows:
Traceback (most recent call last):
  File "D:/swagger_codegen_root/src/swagger_codegen/start.py", line 34, in <module>
    generate('swagger_json.json','petstore')
  File "D:/swagger_codegen_root/src/swagger_codegen/start.py", line 24, in generate
    base_schema = load_base_schema(uri)
  File "G:\Python37\lib\site-packages\swagger_codegen\parsing\loaders.py", line 42, in load_base_schema
    schema = from_file(schema_uri)
  File "G:\Python37\lib\site-packages\swagger_codegen\parsing\loaders.py", line 26, in from_file
    return parsers[Path(file).suffix](file)
  File "G:\Python37\lib\site-packages\swagger_codegen\parsing\loaders.py", line 11, in _from_json
    return json.load(fd)
  File "G:\Python37\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa1 in position 187: illegal multibyte sequence
